### PR TITLE
Remove use of obsolete data-widget-id from twitter embed.

### DIFF
--- a/content/twitterwidget.inc
+++ b/content/twitterwidget.inc
@@ -1,4 +1,4 @@
 <div class="mb-3">
-  <a class="twitter-timeline" width="650" height="400" data-chrome="noheader nofooter" href="https://twitter.com/CMUBuggy" data-widget-id="454018447379161088">Tweets by @CMUBuggy</a>
+  <a class="twitter-timeline" width="650" height="400" data-chrome="noheader nofooter" href="https://twitter.com/CMUBuggy?ref_src=twsrc%5Etfw">Tweets by @CMUBuggy</a>
   <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 </div>


### PR DESCRIPTION
This is generating an error on the JS console, and has been obsolete
for several years.

See: https://twittercommunity.com/t/deprecating-widget-settings/102295

Also adds the ref_src value that the current "Create an embed" code includes, though it does appear to be optional.

No visible change.