### PR TITLE
Remove the use of CAST() for video table queries.

### DIFF
--- a/content/history/buggy.inc
+++ b/content/history/buggy.inc
@@ -50,22 +50,22 @@ $raceQuery = "SELECT e.year,
                                            AND (CONCAT(hp.year,'.',hp.lane1)=e.entryid
                                                 OR CONCAT(hp.year,'.',hp.lane2)=e.entryid
                                                 OR CONCAT(hp.year,'.',hp.lane3)=e.entryid)
-                LEFT JOIN video vp ON CAST(vp.heatid AS CHAR) = hp.heatid
+                LEFT JOIN video vp ON vp.heatid = hp.heatid
                 LEFT JOIN hist_heats hr ON hr.isfinals = 0 AND hr.isreroll = 1
                                            AND (CONCAT(hr.year,'.',hr.lane1)=e.entryid
                                                 OR CONCAT(hr.year,'.',hr.lane2)=e.entryid
                                                 OR CONCAT(hr.year,'.',hr.lane3)=e.entryid)
-                LEFT JOIN video vr ON CAST(vr.heatid AS CHAR) = hr.heatid
+                LEFT JOIN video vr ON vr.heatid = hr.heatid
                 LEFT JOIN hist_heats hf ON hf.isfinals = 1 AND hf.isreroll = 0
                                            AND (CONCAT(hf.year,'.',hf.lane1)=e.entryid
                                                 OR CONCAT(hf.year,'.',hf.lane2)=e.entryid
                                                 OR CONCAT(hf.year,'.',hf.lane3)=e.entryid)
-                LEFT JOIN video vf ON CAST(vf.heatid AS CHAR) = hf.heatid
+                LEFT JOIN video vf ON vf.heatid = hf.heatid
                 LEFT JOIN hist_heats hfr ON hfr.isfinals = 1 AND hfr.isreroll = 1
                                            AND (CONCAT(hfr.year,'.',hfr.lane1)=e.entryid
                                                 OR CONCAT(hfr.year,'.',hfr.lane2)=e.entryid
                                                 OR CONCAT(hfr.year,'.',hfr.lane3)=e.entryid)
-                LEFT JOIN video vfr ON CAST(vfr.heatid AS CHAR) = hfr.heatid
+                LEFT JOIN video vfr ON vfr.heatid = hfr.heatid
                 WHERE e.buggyid = ?
                 ORDER BY year DESC, Team ASC;";
 

--- a/content/history/entry.inc
+++ b/content/history/entry.inc
@@ -32,22 +32,22 @@ $headerQuery = "SELECT e.year, o.orgid, o.shortname AS org,
                                              AND (CONCAT(hp.year,'.',hp.lane1)=e.entryid
                                                   OR CONCAT(hp.year,'.',hp.lane2)=e.entryid
 		                                              OR CONCAT(hp.year,'.',hp.lane3)=e.entryid)
-                  LEFT JOIN video vp ON CAST(vp.heatid AS CHAR) = hp.heatid
+                  LEFT JOIN video vp ON vp.heatid = hp.heatid
                   LEFT JOIN hist_heats hr ON hr.isfinals = 0 AND hr.isreroll = 1
                                              AND (CONCAT(hr.year,'.',hr.lane1)=e.entryid
                                                   OR CONCAT(hr.year,'.',hr.lane2)=e.entryid
 		                                              OR CONCAT(hr.year,'.',hr.lane3)=e.entryid)
-                  LEFT JOIN video vr ON CAST(vr.heatid AS CHAR) = hr.heatid
+                  LEFT JOIN video vr ON vr.heatid = hr.heatid
                   LEFT JOIN hist_heats hf ON hf.isfinals = 1 AND hf.isreroll = 0
                                              AND (CONCAT(hf.year,'.',hf.lane1)=e.entryid
                                                   OR CONCAT(hf.year,'.',hf.lane2)=e.entryid
 		                                              OR CONCAT(hf.year,'.',hf.lane3)=e.entryid)
-                  LEFT JOIN video vf ON CAST(vf.heatid AS CHAR) = hf.heatid
+                  LEFT JOIN video vf ON vf.heatid= hf.heatid
                   LEFT JOIN hist_heats hfr ON hfr.isfinals = 1 AND hfr.isreroll = 1
                                              AND (CONCAT(hfr.year,'.',hfr.lane1)=e.entryid
                                                   OR CONCAT(hfr.year,'.',hfr.lane2)=e.entryid
 		                                              OR CONCAT(hfr.year,'.',hfr.lane3)=e.entryid)
-                  LEFT JOIN video vfr ON CAST(vfr.heatid AS CHAR) = hfr.heatid
+                  LEFT JOIN video vfr ON vfr.heatid = hfr.heatid
                   WHERE entryid = ?;";
 $headerResults = dbBoundQuery($HISTORY_DATABASE, $headerQuery, "s", $urlkey);
 

--- a/content/history/raceday.inc
+++ b/content/history/raceday.inc
@@ -66,10 +66,10 @@
            when isfinals = 1 and isreroll = 1 and e3.finalreroll <= 0 then e3.reroll end AS timesec3,
       h.note, v.youtubeid AS video_youtubeid, v.title AS video_title
     FROM hist_heats h
-    LEFT JOIN hist_raceentries e1 on concat(h.year, '.', Lane1) = e1.entryid LEFT JOIN hist_orgs o1 on e1.orgid = o1.orgid
-    LEFT JOIN hist_raceentries e2 on concat(h.year, '.', Lane2) = e2.entryid LEFT JOIN hist_orgs o2 on e2.orgid = o2.orgid
-    LEFT JOIN hist_raceentries e3 on concat(h.year, '.', Lane3) = e3.entryid LEFT JOIN hist_orgs o3 on e3.orgid = o3.orgid
-    LEFT JOIN video v on h.heatid = CAST(v.heatid as CHAR)
+    LEFT JOIN hist_raceentries e1 ON concat(h.year, '.', Lane1) = e1.entryid LEFT JOIN hist_orgs o1 ON e1.orgid = o1.orgid
+    LEFT JOIN hist_raceentries e2 ON concat(h.year, '.', Lane2) = e2.entryid LEFT JOIN hist_orgs o2 ON e2.orgid = o2.orgid
+    LEFT JOIN hist_raceentries e3 ON concat(h.year, '.', Lane3) = e3.entryid LEFT JOIN hist_orgs o3 ON e3.orgid = o3.orgid
+    LEFT JOIN video v ON h.heatid = v.heatid
     WHERE h.year = ? AND (h.class != 'E' OR v.youtubeid IS NOT NULL)
     ORDER BY h.class,isfinals,isreroll,number ASC;";
 


### PR DESCRIPTION
Requires the video heatid column to be updated to varchar(12) before deployment.
(This is safe to do, since the CAST() itself can work either with int or varchar).

e.g.
ALTER TABLE video CHANGE COLUMN heatid heatid varchar(12);
ALTER TABLE video ADD INDEX (heatid);

Resolves Issue #48 