### PR TITLE
Remove caching for youtube video thumbnails.

### DIFF
--- a/content/youtubevid.inc
+++ b/content/youtubevid.inc
@@ -4,36 +4,20 @@
 if($video){
   $id=$video["youtubeid"];
   $showthumbnail = empty($video["nothumbnail"]);
+?>
 
-  // TODO: It is unclear to me why we cache these.  Youtube has way more serving capacity than we do.
-  //
-  // Check for cached youtube thumb, if found use, if not found get and save
-  if($showthumbnail) {
-    if(file_exists("content/cache/youtube/vidthumb-".$id.".jpg")){
-      $thumbsrc = "/content/cache/youtube/vidthumb-".$id.".jpg";
-    } else {
-      $thumbsrc = "https://i4.ytimg.com/vi/".$id."/default.jpg";
-      if (file_exists("content/cachce/youtube/")) {
-        $thumb = file_get_contents("https://i4.ytimg.com/vi/".$id."/default.jpg");
-        file_put_contents("content/cache/youtube/vidthumb-".$id.".jpg", $thumb);
-      }
-    }
-  }
-
-  // We always show popup-style videos, but we need to choose if the activation button is a link or an image.
-  ?>
   <button type="button" class="btn btn-link p-0" data-toggle="modal" data-target="#youtube-<?php echo $id; ?>">
   <?php
-  if($showthumbnail) {
+    if($showthumbnail) {
+      $title = $video["title"];
+      $thumbsrc = "https://i4.ytimg.com/vi/".$id."/default.jpg";
+      echo("<img alt=\"".$title."\" title=\"".$title."\" width=\"120px\" height=\"90px\" src=\"".$thumbsrc."\">");
+    } else {
+      echo($video["nothumbnail"]);
+    }
   ?>
-    <img alt="<?php echo($video["title"]); ?>" title="<?php echo($video["title"]); ?>" width="120px" height="90px" src="<?php echo($thumbsrc); ?>">
-  <?php
-  } else {
-    echo($video["nothumbnail"]);
-  }
-  ?>
-
   </button>
+
   <div id="youtube-<?php echo $id; ?>" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="#title-<?php echo $id; ?>" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
       <div class="modal-content">


### PR DESCRIPTION
- It doesn't work currently, but even though it is trivial to fix, it is
  not worth doing so, because...
- All this does is cost us our own storage and bandwith to serve images that
  youtube will serve (and, possibly, update) anyway.  So by caching, we
  cost ourselves resources for possibly stale data.  And in the unlikely event
  youtube is down, the image preview isn't that useful anyway.