### PR TITLE
Remove table-responsive wrapper from tables that use video embeds.

### DIFF
--- a/content/history/buggy.inc
+++ b/content/history/buggy.inc
@@ -175,22 +175,21 @@ if(empty($image_url)) {
 </ul>
 <div class="tab-content">
   <div class="tab-pane fade show active" id="tab-races" role="tabpanel" aria-labelledby="races-tab">
-    <div class="table-responsive">
-      <table class="table">
-        <thead>
-          <tr class="text-nowrap">
-            <th>Year</th>
-            <th>Team</th>
-            <th>Place</th>
-            <th>Prelim</th>
-            <th>Prelim Reroll</th>
-            <th>Final</th>
-            <th>Final Reroll</th>
-            <th>DQ / Notes</th>
-          </tr>
-        </thead>
-        <tbody>
-          <?php
+    <table class="table">
+      <thead>
+        <tr class="text-nowrap">
+          <th>Year</th>
+          <th>Team</th>
+          <th>Place</th>
+          <th>Prelim</th>
+          <th>Prelim Reroll</th>
+          <th>Final</th>
+          <th>Final Reroll</th>
+          <th>DQ / Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php
           while ($r = $raceData->fetch_assoc()) {
             $heatorder = array('Prelim', 'Reroll', 'Final', 'FinalReroll');
             $heattypes = array('Prelim' => 'p','Reroll' => 'r','Final' => 'f', 'FinalReroll' => 'fr');
@@ -251,10 +250,9 @@ if(empty($image_url)) {
             }
             echo("<td>".$r["DQ"]." ".$r["note"]."</td></tr>");
           }
-          ?>
-        </tbody>
-      </table>
-    </div>
+        ?>
+      </tbody>
+    </table>
   </div>
   <div class="tab-pane fade" id="tab-awards" role="tabpanel" aria-labelledby="awards-tab">
     <div class="table-responsive">

--- a/content/history/raceday.inc
+++ b/content/history/raceday.inc
@@ -150,7 +150,7 @@
     foreach($heattypes as $type){
       if(isset($heatArr[$type])){
         echo("<h4>".$heattypelabels[$type]."</h4>");
-        echo("<div class\"table-responsive\"><table class=\"table\"><thead>");
+        echo("<table class=\"table\"><thead>");
 
         if ($type != "E0") {
           // Not Exhibition, Add useful headers.
@@ -198,7 +198,7 @@
           }
           echo("</tr>");
         }
-        echo("</tbody></table></div>");
+        echo("</tbody></table>");
       }
     }
   }


### PR DESCRIPTION
table-responsive breaks modals on ios (both chrome and safari).
In this case, the raceday page never actually used this tag due to
a typo, so this is only a behavior change on the buggy page.