### PR TITLE
Disable xmlrpc for wordpress.

### DIFF
--- a/news/.htaccess
+++ b/news/.htaccess
@@ -28,3 +28,15 @@ RewriteRule . /news/index.php [L]
 </IfModule>
 
 # END WordPress
+
+# BEGIN DS-XML-RPC-API
+# The directives (lines) between "BEGIN DS-XML-RPC-API" and "END DS-XML-RPC-API" are
+# dynamically generated, and should only be modified via WordPress filters.
+# Any changes to the directives between these markers will be overwritten.
+<Files xmlrpc.php>
+order deny,allow
+deny from all
+
+</Files>
+
+# END DS-XML-RPC-API


### PR DESCRIPTION
Only used for remote publishing and it looks like we were being used as an attack reflector via this.