### PR TITLE
Delete on-page titles from static pages.

### DIFF
--- a/content/history/intro.inc
+++ b/content/history/intro.inc
@@ -1,5 +1,3 @@
-<h1>The History of Buggy</h1>
-
 <div class="container">
  <div class="row">
    <div class="col">

--- a/content/tvportal.inc
+++ b/content/tvportal.inc
@@ -6,8 +6,6 @@
     // No page selected, just show the index (included below)
 ?>
 
-<h1>BAA TV Portal</h1>
-
 <ul>
   <li><a href="/tvportal/leaderboard">Leaderboard Views</li>
   <li><a href="/tvportal/rosters">Roster Views</li>


### PR DESCRIPTION
They are now in the header itself.