### PR TITLE
History Page Breadcrumb Infrastructure

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -165,7 +165,7 @@ RewriteRule		^history/raceday[/]*$								index.php?s=history&p=racedaylist				[
 # record is obsolete, but keep it here to allow any dead links to work.
 RewriteRule		^history/record[/]*$								index.php?s=history&p=toptimes 					[NC,L]
 RewriteRule		^history/toptimes[/]*$								index.php?s=history&p=toptimes 					[NC,L]
-RewriteRule		^history/sweepstakes[/]*$							index.php?s=history&p=sweepstakes 				[NC,L]
+RewriteRule		^history/sweepstakes[/]*$							index.php?s=history&p=sweepstakeslist 				[NC,L]
 # team without a url parameter we will send to the org list, since there isn't an "entry list" per se.
 RewriteRule		^history/team[/]*$									index.php?s=history&p=orglist					[NC,L]
 

--- a/content/history/masthead-data.inc
+++ b/content/history/masthead-data.inc
@@ -10,20 +10,11 @@ function getHistoryBreadcrumbs() {
         "org" => ['/history/org', "Organizations"],
         "person" => ['/history/person', "People"],
         "raceday" => ['/history/raceday', "Racedays"],
+        "sweepstakes" => ['/history/sweepstakes', "Sweepstakes Committees"],
 
         // There isn't really a /history/entries page.
         // Going to use orgs, but could arguably be racedays too.
         "entry" => ['/history/org', "Organizations"],
-
-        // TODO: Sweepstakes can run in 2 modes, one with a urlkey (year) and
-        // one for the overall list.
-        // Options:
-        //  - Ignore it
-        //  - Split sweepstakes into sweepstakes and sweepstakeslist to be consistent with other pages
-        //  - Custom handling in this file
-        // "sweepstakes" => ['/history/sweepstakes', "Sweepstakes Committees"],
-        // For now, no breadcrumb and a specific title that doesn't include the year.
-
 
         // These pages exist, but are the top level and shouldn't get a dedicated breadcrumb.
         // Instead, they just get their title and the History breadcrumb.
@@ -34,6 +25,7 @@ function getHistoryBreadcrumbs() {
         // "orglist" => ['/history/org', "Organizations"],
         // "personlist" => ['/history/person', "People"],
         // "racedaylist" => ['/history/raceday', "Racedays"],
+        // "sweepstakeslist" => ['/history/sweepstakes', "Sweepstakes Committees"],
         // "toptimes" => ['/history/toptimes', "Top Times"]
     ];
 
@@ -57,6 +49,7 @@ function getHistoryPageTitle() {
         // "person" => "Connor Hayes"
         // "raceday" => "2023"
         // "entry" => "2023 Spirit Womens A"
+        // "sweepstakes" => "Sweepstakes Committee 2023"
 
         // TODO: Sweepstakes is special, see note above.
 
@@ -66,7 +59,7 @@ function getHistoryPageTitle() {
         "orglist" => "Organizations",
         "personlist" => "People Search",
         "racedaylist" => "Racedays",
-        "sweepstakes" => "Sweepstakes Committees",
+        "sweepstakeslist" => "Sweepstakes Committees",
         "toptimes" => "Top Times"
     ];
 

--- a/content/history/masthead-data.inc
+++ b/content/history/masthead-data.inc
@@ -1,0 +1,81 @@
+<?php
+function getHistoryBreadcrumbs() {
+    // If we are here, we always have at least the /history crumb.
+    $ret = [["/history", "History"]];
+
+    // The map of deeper crumbs.
+    $CRUMB_MAP = [
+        // Entity pages need the breadcrumb for their prior level.
+        "buggy" => ['/history/buggy', "Buggies"],
+        "org" => ['/history/org', "Organizations"],
+        "person" => ['/history/person', "People"],
+        "raceday" => ['/history/raceday', "Racedays"],
+
+        // There isn't really a /history/entries page.
+        // Going to use orgs, but could arguably be racedays too.
+        "entry" => ['/history/org', "Organizations"],
+
+        // TODO: Sweepstakes can run in 2 modes, one with a urlkey (year) and
+        // one for the overall list.
+        // Options:
+        //  - Ignore it
+        //  - Split sweepstakes into sweepstakes and sweepstakeslist to be consistent with other pages
+        //  - Custom handling in this file
+        // "sweepstakes" => ['/history/sweepstakes', "Sweepstakes Committees"],
+        // For now, no breadcrumb and a specific title that doesn't include the year.
+
+
+        // These pages exist, but are the top level and shouldn't get a dedicated breadcrumb.
+        // Instead, they just get their title and the History breadcrumb.
+        //
+        // "awards" => ['/history/award', "Awards"],
+        // "buggybook" => ['/history/buggybook', "Buggy Books"],
+        // "buggylist" => ['/history/buggy', "Buggies"],
+        // "orglist" => ['/history/org', "Organizations"],
+        // "personlist" => ['/history/person', "People"],
+        // "racedaylist" => ['/history/raceday', "Racedays"],
+        // "toptimes" => ['/history/toptimes', "Top Times"]
+    ];
+
+    if (empty($_GET['p'])
+        || !in_array($_GET['p'], array_keys($CRUMB_MAP))) {
+        // Either this is the top page, or it is a subpage that doesn't get a crumb.
+        return $ret;
+    } else {
+        array_push($ret, $CRUMB_MAP[$_GET['p']]);
+        return $ret;
+    }
+}
+
+function getHistoryPageTitle() {
+    // Map subpages to titles.
+    $TITLE_MAP = [
+        // TODO:
+        // These pages will need custom handling, as the title needs to be read from the DB.
+        // "buggy" => "Stealth"
+        // "org" => "Apex"
+        // "person" => "Connor Hayes"
+        // "raceday" => "2023"
+        // "entry" => "2023 Spirit Womens A"
+
+        // TODO: Sweepstakes is special, see note above.
+
+        "awards" => "Awards",
+        "buggybook" => "Buggy Books",
+        "buggylist" => "Buggies",
+        "orglist" => "Organizations",
+        "personlist" => "People Search",
+        "racedaylist" => "Racedays",
+        "sweepstakes" => "Sweepstakes Committees",
+        "toptimes" => "Top Times"
+    ];
+
+    if (empty($_GET['p'])
+        || !in_array($_GET['p'], array_keys($TITLE_MAP))) {
+        // Either this is the top page, or we don't know what it is.  Default to "History"
+        return "History";
+    } else {
+        return $TITLE_MAP[$_GET['p']];
+    }
+}
+?>

--- a/content/history/personlist.inc
+++ b/content/history/personlist.inc
@@ -28,8 +28,6 @@
   }
 ?>
 
-<h1>People Search</h1>
-
 <p>The history database currently includes people that we have records for as raceday pushers, drivers, and members of the sweepstakes committee.</p>
 <form method="get" action="/history/person">
 <div class="form-inline my-2">

--- a/content/history/racedaylist.inc
+++ b/content/history/racedaylist.inc
@@ -1,5 +1,3 @@
-<h1>Racedays</h1>
-
 <?php
 // This query only works for years in one of 3 cases:
 // - No results at all, and there is an entry in the database. (e.g. COVID and War Years)

--- a/content/history/sweepstakes.inc
+++ b/content/history/sweepstakes.inc
@@ -56,14 +56,6 @@
     // Show all years, but only 4 roles.
     $sweeps = getAllSweepstakes();
 ?>
-  <div class="row align-items-center mb-2">
-    <div class="col col-sm-8 col-md-9">
-      <h1>Sweepstakes Committees</h1>
-    </div>
-    <div class="d-none d-sm-flex col justify-content-end">
-      <img class="img-fluid" style="max-height:150px" src="/img/logos/sweepstakes_logo_notext.svg">
-    </div>
-  </div>
   <p class="font-italic">To see the full committee, click on the year.</p>
   <div class="table-responsive">
     <table class="table">

--- a/content/history/sweepstakes.inc
+++ b/content/history/sweepstakes.inc
@@ -1,25 +1,4 @@
 <?php
-  function getAllSweepstakes() {
-    $query = "SELECT DISTINCT y.year,
-                              concat(pch.firstname, ' ', pch.lastname) AS chair, pch.personid AS chairid,
-	                            concat(pac.firstname, ' ', pac.lastname) AS asst, pac.personid AS asstid,
-	                            concat(psf.firstname, ' ', psf.lastname) AS safety, psf.personid AS safetyid,
-	                            concat(phj.firstname, ' ', phj.lastname) AS judge, phj.personid AS judgeid
-                  FROM hist_sweepstakes y
-                    LEFT JOIN hist_sweepstakes ch ON ch.year = y.year AND ch.role = 'Sweepstakes Chairman'
-                      LEFT JOIN hist_people pch ON ch.personid = pch.personid
-	                  LEFT JOIN hist_sweepstakes ac ON ac.year = y.year AND ac.role = 'Assistant Chairman'
-                      LEFT JOIN hist_people pac ON ac.personid = pac.personid
-	                  LEFT JOIN hist_sweepstakes sf ON sf.year = y.year AND sf.role = 'Safety Chairman'
-                      LEFT JOIN hist_people psf ON sf.personid = psf.personid
-	                  LEFT JOIN hist_sweepstakes hj ON hj.year = y.year AND hj.role = 'Head Judge'
-                      LEFT JOIN hist_people phj ON hj.personid = phj.personid
-                  ORDER BY y.year DESC;";
-
-    global $HISTORY_DATABASE;
-    return dbQuery($HISTORY_DATABASE, $query);
-  }
-
   function getSweepstakesYear($year) {
     $query = "SELECT role, concat(p.firstname, ' ', p.lastname) AS name, s.personid AS id
                 FROM hist_sweepstakes s
@@ -31,57 +10,29 @@
     return dbBoundQuery($HISTORY_DATABASE, $query, "d", $year);
   }
 
-  // If "year" parameter is supplied, show all known positions for that year.
-  if(!empty($_GET["year"])){
-    $year = $_GET["year"];
-    $sweeps = getSweepstakesYear($_GET["year"]);
-
+  // Should always have a year, due to htaccess routing.
+  $year = $_GET["year"];
+  $sweeps = getSweepstakesYear($_GET["year"]);
 ?>
-    <div class="row align-items-center mb-4">
-      <div class="col col-sm-8 col-md-9">
-        <h1 class="text-center">Sweepstakes Committee <?php echo($year);?></h1>
-      </div>
-      <div class="d-none d-sm-flex col justify-content-end">
-        <img class="img-fluid" style="max-height:150px" src="/img/logos/sweepstakes_logo_notext.svg">
-      </div>
+  <div class="row align-items-center mb-4">
+    <div class="col col-sm-8 col-md-9">
+      <h1 class="text-center">Sweepstakes Committee <?php echo($year);?></h1>
     </div>
+    <div class="d-none d-sm-flex col justify-content-end">
+      <img class="img-fluid" style="max-height:150px" src="/img/logos/sweepstakes_logo_notext.svg">
+    </div>
+  </div>
 <?php
-
+  if ($sweeps->num_rows > 0) {
     echo("<dl class=\"row\">");
     while($r = $sweeps->fetch_assoc()) {
       echo("<dt class=\"col-6 my-1 d-sm-flex justify-content-end\">".$r["role"]."</dt>");
       echo("<dd class=\"col-6 my-1 d-flex align-items-center\"><a href=\"/history/person/".$r["id"]."\">".$r["name"]."</a></dd>");
     }
+    echo("</dl>");
   } else {
-    // Show all years, but only 4 roles.
-    $sweeps = getAllSweepstakes();
+    echo("<i>Sorry, no committee data exists for this year.</i>");
+  }
 ?>
-  <p class="font-italic">To see the full committee, click on the year.</p>
-  <div class="table-responsive">
-    <table class="table">
-      <thead>
-        <tr>
-          <th>Year</th>
-          <th>Sweepstakes Chair</th>
-          <th>Assistant Chair</th>
-          <th>Safety Chair</th>
-          <th>Head Judge</th>
-        </tr>
-      </thead>
-      <tbody>
-        <?php
-          while($s = $sweeps->fetch_assoc()) {
-            echo "<tr>";
-            echo "<td><a href=\"/history/sweepstakes/".$s["year"]."\">".$s["year"]."</a></td>";
-            echo "<td><a href=\"/history/person/".$s["chairid"]."\">".$s["chair"]."</a></td>";
-            echo "<td><a href=\"/history/person/".$s["asstid"]."\">".$s["asst"]."</a></td>";
-            echo "<td><a href=\"/history/person/".$s["safetyid"]."\">".$s["safety"]."</a></td>";
-            echo "<td><a href=\"/history/person/".$s["judgeid"]."\">".$s["judge"]."</a></td>";
-            echo "</tr>";
-          }
-        ?>
-      </tbody>
-    </table>
-  </div>
-<?php } ?>
+
 

--- a/content/history/sweepstakeslist.inc
+++ b/content/history/sweepstakeslist.inc
@@ -1,0 +1,53 @@
+<?php
+  function getAllSweepstakes() {
+    $query = "SELECT DISTINCT y.year,
+                              concat(pch.firstname, ' ', pch.lastname) AS chair, pch.personid AS chairid,
+	                            concat(pac.firstname, ' ', pac.lastname) AS asst, pac.personid AS asstid,
+	                            concat(psf.firstname, ' ', psf.lastname) AS safety, psf.personid AS safetyid,
+	                            concat(phj.firstname, ' ', phj.lastname) AS judge, phj.personid AS judgeid
+                  FROM hist_sweepstakes y
+                    LEFT JOIN hist_sweepstakes ch ON ch.year = y.year AND ch.role = 'Sweepstakes Chairman'
+                      LEFT JOIN hist_people pch ON ch.personid = pch.personid
+	                  LEFT JOIN hist_sweepstakes ac ON ac.year = y.year AND ac.role = 'Assistant Chairman'
+                      LEFT JOIN hist_people pac ON ac.personid = pac.personid
+	                  LEFT JOIN hist_sweepstakes sf ON sf.year = y.year AND sf.role = 'Safety Chairman'
+                      LEFT JOIN hist_people psf ON sf.personid = psf.personid
+	                  LEFT JOIN hist_sweepstakes hj ON hj.year = y.year AND hj.role = 'Head Judge'
+                      LEFT JOIN hist_people phj ON hj.personid = phj.personid
+                  ORDER BY y.year DESC;";
+
+    global $HISTORY_DATABASE;
+    return dbQuery($HISTORY_DATABASE, $query);
+  }
+
+  // Show all years, but only 4 roles.
+  $sweeps = getAllSweepstakes();
+?>
+<p class="font-italic">To see the full committee, click on the year.</p>
+<div class="table-responsive">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Year</th>
+        <th>Sweepstakes Chair</th>
+        <th>Assistant Chair</th>
+        <th>Safety Chair</th>
+        <th>Head Judge</th>
+      </tr>
+    </thead>
+    <tbody>
+      <?php
+        while($s = $sweeps->fetch_assoc()) {
+          echo "<tr>";
+          echo "<td><a href=\"/history/sweepstakes/".$s["year"]."\">".$s["year"]."</a></td>";
+          echo "<td><a href=\"/history/person/".$s["chairid"]."\">".$s["chair"]."</a></td>";
+          echo "<td><a href=\"/history/person/".$s["asstid"]."\">".$s["asst"]."</a></td>";
+          echo "<td><a href=\"/history/person/".$s["safetyid"]."\">".$s["safety"]."</a></td>";
+          echo "<td><a href=\"/history/person/".$s["judgeid"]."\">".$s["judge"]."</a></td>";
+          echo "</tr>";
+        }
+      ?>
+    </tbody>
+  </table>
+</div>
+

--- a/content/pre-content.inc
+++ b/content/pre-content.inc
@@ -79,10 +79,28 @@
 
 <?php
   // Check to see if someone has disabled breadcrumbs on this page
-  if ($SHOW_BREADCRUMBS) {
-    // TODO: Actual breadcrumbs
-    // We use text-reset here to keep the link black, but still retain the hover-underline effect.
-    echo("<a class=\"text-reset\" href=\"/\">Home</a> > $BASE_TITLE");
+  if ($SHOW_BREADCRUMBS && count($BREADCRUMB_LIST) > 0) {
+    // Breadcrumps are a list of 2-item lists (url, title).
+    // If the URL is an empty string, don't linkify it.
+
+    $first_crumb = true;
+    foreach($BREADCRUMB_LIST as $crumb) {
+      if (!$first_crumb) {
+        echo(" > ");
+      } else {
+        $first_crumb = false;
+      }
+      $url = $crumb[0];
+      $text = $crumb[1];
+      if ($url != "") {
+        // We use text-reset here to keep the link black, but still retain the hover-underline effect.
+        echo("<a class=\"text-reset\" href=\"/\">");
+      }
+      echo($text);
+      if ($url != "") {
+        echo("</a>");
+      }
+    }
   } else {
     // Needed for consistent spacing on the home page.
     echo("&nbsp;");

--- a/content/pre-content.inc
+++ b/content/pre-content.inc
@@ -94,7 +94,7 @@
       $text = $crumb[1];
       if ($url != "") {
         // We use text-reset here to keep the link black, but still retain the hover-underline effect.
-        echo("<a class=\"text-reset\" href=\"/\">");
+        echo("<a class=\"text-reset\" href=\"$url\">");
       }
       echo($text);
       if ($url != "") {

--- a/index.php
+++ b/index.php
@@ -30,8 +30,9 @@
     case "history":
       include_once("./content/history/opengraph/opengraphdata.inc");
       $OGMAP = getHistoryOpenGraphContent($OGMAP);
-      $BASE_TITLE = "History";
-      array_push($BREADCRUMB_LIST, ["/history", "History"]);
+      include_once("./content/history/masthead-data.inc");
+      $BREADCRUMB_LIST = array_merge($BREADCRUMB_LIST, getHistoryBreadcrumbs());
+      $BASE_TITLE = getHistoryPageTitle();
       break;
     case "search":
       // Disabled in new design

--- a/index.php
+++ b/index.php
@@ -10,6 +10,7 @@
   }
 
   $SHOW_BREADCRUMBS = true;  // False will indicate to hide the breadcrumbs (e.g. home page)
+  $BREADCRUMB_LIST = [["/", "Home"]];  // List of breadcrumb (url, text) pairs.
   $BAA_TITLE = "CMU Buggy Alumni Association";  // Used to build titles.
   $BASE_TITLE = "";  // Title visible on the page, if any
   $TITLE_TAG = "";  // HTML <title> tag contents
@@ -20,23 +21,31 @@
     // TODO: Default "og:url" (apparently facebook cannot render og:image without it?)
   );
 
-  // TODO: Call down into a module and return a better BASE_TITLE, where appropriate.
+  // Pre-Content Data Collection.
+  // - Opengraph
+  // - Title
+  // - Breadcrumbs
+  // TODO: Call down into a module and return a better BASE_TITLE and additional breadcrumbs, where appropriate.
   switch($s){
     case "history":
       include_once("./content/history/opengraph/opengraphdata.inc");
       $OGMAP = getHistoryOpenGraphContent($OGMAP);
       $BASE_TITLE = "History";
+      array_push($BREADCRUMB_LIST, ["/history", "History"]);
       break;
     case "search":
+      // Disabled in new design
       $BASE_TITLE = "Search Results";
       break;
     case "raceday":
       include_once("./content/raceday/opengraph/opengraphdata.inc");
       $OGMAP = getRacedayOpenGraphContent($OGMAP);
       $BASE_TITLE = "Raceday";
+      array_push($BREADCRUMB_LIST, ["/raceday", "Raceday"]);
       break;
     case "tvportal":
       $BASE_TITLE = "TV Portal";
+      array_push($BREADCRUMB_LIST, ["/tvportal", "TV Portal"]);
       break;
   }
 

--- a/news/wp-content/themes/cmubuggy-child/header.php
+++ b/news/wp-content/themes/cmubuggy-child/header.php
@@ -2,14 +2,23 @@
 	include_once('../util.inc');
 
   $SHOW_BREADCRUMBS = true;
-	// Determine our title tag for cssjs.inc.
-	$BASE_TITLE = "BAA News";
-	if ( is_singular() ) {
-	  $BASE_TITLE = esc_attr(wp_strip_all_tags(get_the_title()));
-	} else {
-	  $BASE_TITLE = "BAA News: " . esc_attr(wp_strip_all_tags(get_the_archive_title()));
-	}
-  $TITLE_TAG = $BASE_TITLE." | CMU Buggy Alumni Association";  
+  if (!defined($BREADCRUMB_LIST) || count($BREADCRUMB_LIST) == 0) {
+	// If someone has set something up before header.php is called, keep using that.
+	$BREADCRUMB_LIST = [["/", "Home"]];  // List of breadcrumb (url, text) pairs.
+  }
+
+  // Determine our title tag for cssjs.inc & title/breadcrumbs for pre-content.inc
+  $BASE_TITLE = "BAA News";
+  if ( is_singular() ) {
+    $BASE_TITLE = esc_attr(wp_strip_all_tags(get_the_title()));
+  } else {
+    $BASE_TITLE = "BAA News: " . esc_attr(wp_strip_all_tags(get_the_archive_title()));
+  }
+  $TITLE_TAG = $BASE_TITLE." | CMU Buggy Alumni Association";
+
+  // TODO: something more useful, including URLs for intermediate stuff.
+  // TBD: breadcrumbs may need to be done in other files, (e.g. page.php, archive.php) before we get here.
+  array_push($BREADCRUMB_LIST, ["", $BASE_TITLE]);
 ?>
 <!doctype html>
 <html>


### PR DESCRIPTION
- Add overall breadcrumb infrastructure - a list of url, title pairs that is expanded into a breadcrumb chain in pre-content.
- Handle non-custom titles and breadcrumbs for history pages.  Still need to do entity-specific pages (e.g. specific orgs, buggies, entries, etc).
- Split sweepstakes committe handling into a list file and a year specific file to simplify masthead logic.