### PR TITLE
Tell Yoast Dupliate Post not to duplicate the discord webhook tombstone.

### DIFF
--- a/news/wp-content/themes/cmubuggy-child/functions.php
+++ b/news/wp-content/themes/cmubuggy-child/functions.php
@@ -5,6 +5,13 @@ add_filter( 'show_admin_bar', '__return_false' );
 // Force exact matching instead of prefix matching for /news/... URLs.
 add_filter('strict_redirect_guess_404_permalink', '__return_true');
 
+// Yoast Duplicate Post and Discod Webhook Plugins fight eachother.  Stop that.
+function clear_webhook_on_duplicate( $meta_excludelist ) {
+    return array_merge( $meta_excludelist, [ '_discord_webhook_published' ] );
+}
+add_filter('duplicate_post_excludelist_filter', 'clear_webhook_on_duplicate');
+
+// Add our CSS scripts.
 function buggy_theme_enqueue_scripts() {
 	// Note: The "Clear Cache For Me" plugin usurps the versioning control
 	// here, so in order to cachebust a new CSS version, you will need to click the


### PR DESCRIPTION
Sad Hack: This goes in our theme so we don't need to fork the plugins.